### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ php bin/console fos:js-routing:dump
 ### 3. Run fixtures
 
 ```
-php bin/console doctrine:fixtures:load --no-interaction
+php bin/console doctrine:schema:drop --force && php bin/console doctrine:schema:update --force && php bin/console doctrine:fixtures:load --no-interaction
 ```
 
 ## Login


### PR DESCRIPTION
Current command won't run when dtdemo database doesn't exist yet (which is the case when DtBundleDemo is just cloned).